### PR TITLE
Add documentation on JUnit5 support

### DIFF
--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
@@ -4,7 +4,6 @@ import com.example.helloworld.core.Person;
 import com.example.helloworld.db.PersonDAO;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
-import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +13,7 @@ import javax.ws.rs.core.Response;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for {@link PersonResource}.
@@ -27,7 +23,6 @@ public class PersonResourceTest {
     private static final PersonDAO DAO = mock(PersonDAO.class);
     public static final ResourceExtension RULE = ResourceExtension.builder()
             .addResource(new PersonResource(DAO))
-            .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .build();
     private Person person;
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DropwizardTestSupportTest {
+class DropwizardTestSupportTest {
     private static final TestServiceListener<TestConfiguration> TEST_SERVICE_LISTENER = new TestServiceListener<>();
     private static final TestManaged TEST_MANAGED = new TestManaged();
     private static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT =

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/FixtureHelpersTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/FixtureHelpersTest.java
@@ -6,14 +6,14 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-public class FixtureHelpersTest {
+class FixtureHelpersTest {
     @Test
-    public void readsTheFileAsAString() {
+    void readsTheFileAsAString() {
         assertThat(fixture("fixtures/fixture.txt")).isEqualTo("YAY FOR ME");
     }
 
     @Test
-    public void throwsIllegalStateExceptionWhenFileDoesNotExist() {
+    void throwsIllegalStateExceptionWhenFileDoesNotExist() {
         assertThatIllegalArgumentException().isThrownBy(() -> fixture("this-does-not-exist.foo"));
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionConfigTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DAOTestExtensionConfigTest {
-    public final DAOTestExtension database = DAOTestExtension.newBuilder()
+class DAOTestExtensionConfigTest {
+    private final DAOTestExtension database = DAOTestExtension.newBuilder()
         .setUrl("jdbc:h2:mem:rule-config-test")
         .setDriver(org.h2.Driver.class)
         .setUsername("username")
@@ -21,7 +21,7 @@ public class DAOTestExtensionConfigTest {
         .build();
 
     @Test
-    public void explicitConfigCreatesSessionFactory() {
+    void explicitConfigCreatesSessionFactory() {
         // it yields a valid SessionFactory instance
         assertThat(database.getSessionFactory()).isNotNull();
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionTest.java
@@ -14,25 +14,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DAOTestExtensionTest {
-    public final DAOTestExtension daoTestExtension = DAOTestExtension.newBuilder().addEntityClass(TestEntity.class).build();
+class DAOTestExtensionTest {
+    private final DAOTestExtension daoTestExtension = DAOTestExtension.newBuilder().addEntityClass(TestEntity.class).build();
 
     @Test
-    public void extensionCreatedSessionFactory() {
+    void extensionCreatedSessionFactory() {
         final SessionFactory sessionFactory = daoTestExtension.getSessionFactory();
 
         assertThat(sessionFactory).isNotNull();
     }
 
     @Test
-    public void extensionCanOpenTransaction() {
+    void extensionCanOpenTransaction() {
         final Long id = daoTestExtension.inTransaction(() -> persist(new TestEntity("junit 5 description")).getId());
 
         assertThat(id).isNotNull();
     }
 
     @Test
-    public void extensionCanRoundtrip() {
+    void extensionCanRoundtrip() {
         final Long id = daoTestExtension.inTransaction(() -> persist(new TestEntity("junit 5 description")).getId());
 
         final TestEntity testEntity = get(id);
@@ -42,13 +42,13 @@ public class DAOTestExtensionTest {
     }
 
     @Test()
-    public void transactionThrowsExceptionAsExpected() {
+    void transactionThrowsExceptionAsExpected() {
         Throwable throwable = Assertions.assertThrows(ConstraintViolationException.class, () -> daoTestExtension.inTransaction(() -> persist(new TestEntity(null))));
         Assertions.assertEquals(ConstraintViolationException.class, throwable.getClass());
     }
 
     @Test
-    public void rollsBackTransaction() {
+    void rollsBackTransaction() {
         // given a successfully persisted entity
         final TestEntity testEntity = new TestEntity("junit 5 description");
         daoTestExtension.inTransaction(() -> persist(testEntity));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionConfigOverrideTest.java
@@ -12,9 +12,9 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardAppExtensionConfigOverrideTest {
+class DropwizardAppExtensionConfigOverrideTest {
 
-    public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION =
         new DropwizardAppExtension<>(TestApplication.class, resourceFilePath("test-config.yaml"),
             Optional.of("app-rule"),
             config("app-rule", "message", "A new way to say Hooray!"),
@@ -22,7 +22,7 @@ public class DropwizardAppExtensionConfigOverrideTest {
             config("extra", () -> "supplied again"));
 
     @Test
-    public void supportsConfigAttributeOverrides() {
+    void supportsConfigAttributeOverrides() {
         final String content = EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/test")
             .request().get(String.class);
 
@@ -30,7 +30,7 @@ public class DropwizardAppExtensionConfigOverrideTest {
     }
 
     @Test
-    public void supportsSuppliedConfigAttributeOverrides() throws Exception {
+    void supportsSuppliedConfigAttributeOverrides() throws Exception {
         assertThat(System.getProperty("app-rule.extra")).isEqualTo("supplied");
         assertThat(System.getProperty("dw.extra")).isEqualTo("supplied again");
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionResetConfigOverrideTest.java
@@ -11,7 +11,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DropwizardAppExtensionResetConfigOverrideTest {
+class DropwizardAppExtensionResetConfigOverrideTest {
     private final DropwizardAppExtension<TestConfiguration> dropwizardAppExtension = new DropwizardAppExtension<>(
             TestApplication.class,
             resourceFilePath("test-config.yaml"),
@@ -19,7 +19,7 @@ public class DropwizardAppExtensionResetConfigOverrideTest {
             config("app-rule-reset", "message", "A new way to say Hooray!"));
 
     @Test
-    public void test2() throws Exception {
+    void test2() throws Exception {
         dropwizardAppExtension.before();
         assertThat(System.getProperty("app-rule-reset.message")).isEqualTo("A new way to say Hooray!");
         assertThat(System.getProperty("app-rule-reset.extra")).isNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
@@ -16,12 +16,12 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardAppExtensionTest {
-    public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
+class DropwizardAppExtensionTest {
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION =
             new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
 
     @Test
-    public void canGetExpectedResourceOverHttp() {
+    void canGetExpectedResourceOverHttp() {
         final String content = ClientBuilder.newClient().target(
                 "http://localhost:" + EXTENSION.getLocalPort() + "/test").request().get(String.class);
 
@@ -29,25 +29,25 @@ public class DropwizardAppExtensionTest {
     }
 
     @Test
-    public void returnsConfiguration() {
+    void returnsConfiguration() {
         final TestConfiguration config = EXTENSION.getConfiguration();
         assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
-    public void returnsApplication() {
+    void returnsApplication() {
         final DropwizardTestApplication application = EXTENSION.getApplication();
         Assertions.assertNotNull(application);
     }
 
     @Test
-    public void returnsEnvironment() {
+    void returnsEnvironment() {
         final Environment environment = EXTENSION.getEnvironment();
         assertThat(environment.getName()).isEqualTo("DropwizardTestApplication");
     }
 
     @Test
-    public void canPerformAdminTask() {
+    void canPerformAdminTask() {
         final String response
                 = EXTENSION.client().target("http://localhost:"
                 + EXTENSION.getAdminPort() + "/tasks/hello?name=test_user")
@@ -58,7 +58,7 @@ public class DropwizardAppExtensionTest {
     }
 
     @Test
-    public void canPerformAdminTaskWithPostBody() {
+    void canPerformAdminTaskWithPostBody() {
         final String response = EXTENSION.client()
                 .target("http://localhost:" + EXTENSION.getAdminPort() + "/tasks/echo")
                 .request()
@@ -68,7 +68,7 @@ public class DropwizardAppExtensionTest {
     }
 
     @Test
-    public void clientUsesJacksonMapperFromEnvironment() {
+    void clientUsesJacksonMapperFromEnvironment() {
         final Optional<String> message = EXTENSION.client()
                 .target("http://localhost:" + EXTENSION.getLocalPort() + "/message")
                 .request()
@@ -79,7 +79,7 @@ public class DropwizardAppExtensionTest {
     }
 
     @Test
-    public void clientSupportsPatchMethod() {
+    void clientSupportsPatchMethod() {
         final String method = EXTENSION.client()
                 .target("http://localhost:" + EXTENSION.getLocalPort() + "/echoPatch")
                 .request()

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithExplicitTest.java
@@ -18,9 +18,9 @@ import java.util.Collections;
 import java.util.Map;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardAppExtensionWithExplicitTest {
+class DropwizardAppExtensionWithExplicitTest {
 
-    public static final DropwizardAppExtension<TestConfiguration> EXTENSION;
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION;
 
     static {
         // Bit complicated, as we want to avoid using the default http port (8080)
@@ -35,7 +35,7 @@ public class DropwizardAppExtensionWithExplicitTest {
 
 
     @Test
-    public void runWithExplicitConfig() {
+    void runWithExplicitConfig() {
         Map<?, ?> response = EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/test")
                 .request()
                 .get(Map.class);
@@ -54,7 +54,7 @@ public class DropwizardAppExtensionWithExplicitTest {
     public static class TestResource {
         private final String message;
 
-        public TestResource(String m) {
+        TestResource(String m) {
             message = m;
         }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithoutConfigTest.java
@@ -17,14 +17,14 @@ import java.util.Collections;
 import java.util.Map;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardAppExtensionWithoutConfigTest {
+class DropwizardAppExtensionWithoutConfigTest {
 
-    public static final DropwizardAppExtension<Configuration> EXTENSION = new DropwizardAppExtension<>(TestApplication.class, null,
+    private static final DropwizardAppExtension<Configuration> EXTENSION = new DropwizardAppExtension<>(TestApplication.class, null,
         ConfigOverride.config("server.applicationConnectors[0].port", "0"),
         ConfigOverride.config("server.adminConnectors[0].port", "0"));
 
     @Test
-    public void runWithoutConfigFile() {
+    void runWithoutConfigFile() {
         Map<?, ?> response = EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/test")
             .request()
             .get(Map.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardClientExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardClientExtensionTest.java
@@ -12,19 +12,19 @@ import java.nio.charset.StandardCharsets;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardClientExtensionTest {
+class DropwizardClientExtensionTest {
 
-    public static final DropwizardClientExtension EXTENSION_WITH_INSTANCE = new DropwizardClientExtension(new TestResource("foo"));
-    public static final DropwizardClientExtension EXTENSION_WITH_CLASS = new DropwizardClientExtension(TestResource.class);
+    private static final DropwizardClientExtension EXTENSION_WITH_INSTANCE = new DropwizardClientExtension(new TestResource("foo"));
+    private static final DropwizardClientExtension EXTENSION_WITH_CLASS = new DropwizardClientExtension(TestResource.class);
 
     @Test
-    public void shouldGetStringBodyFromDropWizard() throws IOException {
+    void shouldGetStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(EXTENSION_WITH_INSTANCE.baseUri() + "/test");
         assertThat("foo").isEqualTo(Resources.toString(url, StandardCharsets.UTF_8));
     }
 
     @Test
-    public void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
+    void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(EXTENSION_WITH_CLASS.baseUri() + "/test");
         assertThat(Resources.toString(url, StandardCharsets.UTF_8)).isEqualTo(TestResource.DEFAULT_MESSAGE);
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/GzipDefaultVaryBehaviourTest.java
@@ -15,13 +15,13 @@ import static javax.ws.rs.core.HttpHeaders.VARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class GzipDefaultVaryBehaviourTest {
+class GzipDefaultVaryBehaviourTest {
 
     private DropwizardAppExtension<TestConfiguration> extension = new DropwizardAppExtension<>(TestApplication.class,
         resourceFilePath("gzip-vary-test-config.yaml"));
 
     @Test
-    public void testDefaultVaryHeader() {
+    void testDefaultVaryHeader() {
         final Response clientResponse = extension.client().target(
             "http://localhost:" + extension.getLocalPort() + "/test").request().header(ACCEPT_ENCODING, "gzip").get();
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceExceptionMapperTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class PersonResourceExceptionMapperTest {
+class PersonResourceExceptionMapperTest {
 
     private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
         .registerModule(new GuavaModule());
@@ -35,7 +35,7 @@ public class PersonResourceExceptionMapperTest {
         .build();
 
     @Test
-    public void testDefaultConstraintViolation() {
+    void testDefaultConstraintViolation() {
         assertThat(resources.target("/person/blah/index")
             .queryParam("ind", -1).request()
             .get().readEntity(String.class))
@@ -43,7 +43,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    public void testDefaultJsonProcessingMapper() {
+    void testDefaultJsonProcessingMapper() {
         assertThat(resources.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{ \"he: \"ho\"}"))
@@ -52,7 +52,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    public void testDefaultExceptionMapper() {
+    void testDefaultExceptionMapper() {
         assertThat(resources.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{}"))
@@ -61,7 +61,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    public void testDefaultEofExceptionMapper() {
+    void testDefaultEofExceptionMapper() {
         assertThat(resources.target("/person/blah/eof-exception")
             .request()
             .get().readEntity(String.class))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
  * Tests {@link ResourceTestRule}.
  */
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class PersonResourceTest {
+class PersonResourceTest {
     private static class DummyExceptionMapper implements ExceptionMapper<WebApplicationException> {
         @Override
         public Response toResponse(WebApplicationException e) {
@@ -48,12 +48,12 @@ public class PersonResourceTest {
     private Person person = new Person("blah", "blah@example.com");
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(peopleStore.fetchPerson("blah")).thenReturn(person);
     }
 
     @Test
-    public void testGetPerson() {
+    void testGetPerson() {
         assertThat(resources.target("/person/blah").request()
             .get(Person.class))
             .isEqualTo(person);
@@ -61,13 +61,13 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testGetImmutableListOfPersons() {
+    void testGetImmutableListOfPersons() {
         assertThat(resources.target("/person/blah/list").request().get(new GenericType<List<Person>>() {
             })).containsOnly(person);
     }
 
     @Test
-    public void testGetPersonWithQueryParam() {
+    void testGetPersonWithQueryParam() {
         // Test to ensure that the dropwizard validator is registered so that
         // it can validate the "ind" IntParam.
         assertThat(resources.target("/person/blah/index")
@@ -78,7 +78,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testDefaultConstraintViolation() {
+    void testDefaultConstraintViolation() {
         assertThat(resources.target("/person/blah/index")
             .queryParam("ind", -1).request()
             .get().readEntity(String.class))
@@ -86,7 +86,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testDefaultJsonProcessingMapper() {
+    void testDefaultJsonProcessingMapper() {
         assertThat(resources.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{ \"he: \"ho\"}"))
@@ -95,7 +95,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testDefaultExceptionMapper() {
+    void testDefaultExceptionMapper() {
         assertThat(resources.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{}"))
@@ -104,7 +104,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testDefaultEofExceptionMapper() {
+    void testDefaultEofExceptionMapper() {
         assertThat(resources.target("/person/blah/eof-exception")
             .request()
             .get().getStatus())
@@ -112,7 +112,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testValidationGroupsException() {
+    void testValidationGroupsException() {
         final Response resp = resources.target("/person/blah/validation-groups-exception")
             .request()
             .post(Entity.json("{}"));
@@ -123,7 +123,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void testCustomClientConfiguration() {
+    void testCustomClientConfiguration() {
         assertThat(resources.client().getConfiguration().isRegistered(DummyExceptionMapper.class)).isTrue();
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithGrizzlyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithGrizzlyTest.java
@@ -22,7 +22,7 @@ class ResourceExtensionWithGrizzlyTest {
         .build();
 
     @Test
-    public void testClientSupportsPatchMethod() {
+    void testClientSupportsPatchMethod() {
         final String resp = resources.target("test")
             .request()
             .method("PATCH", Entity.text("Patch is working"), String.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ReuseDropwizardAppExtensionTestSuite.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ReuseDropwizardAppExtensionTestSuite.java
@@ -11,18 +11,18 @@ import javax.ws.rs.core.MediaType;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ReuseDropwizardAppExtensionTestSuite {
-    public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
+class ReuseDropwizardAppExtensionTestSuite {
+    static final DropwizardAppExtension<TestConfiguration> EXTENSION =
         new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
 
 }
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardAppExtensionTestSuiteFoo {
-    public static final DropwizardAppExtension<TestConfiguration> EXTENSION = ReuseDropwizardAppExtensionTestSuite.EXTENSION;
+    static final DropwizardAppExtension<TestConfiguration> EXTENSION = ReuseDropwizardAppExtensionTestSuite.EXTENSION;
 
     @Test
-    public void clientHasNotBeenClosed() {
+    void clientHasNotBeenClosed() {
         final String response = EXTENSION.client()
                 .target("http://localhost:" + EXTENSION.getAdminPort() + "/tasks/echo")
                 .request()
@@ -34,10 +34,10 @@ class DropwizardAppExtensionTestSuiteFoo {
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardAppExtensionTestSuiteBar {
-    public static final DropwizardAppExtension<TestConfiguration> EXTENSION = ReuseDropwizardAppExtensionTestSuite.EXTENSION;
+    static final DropwizardAppExtension<TestConfiguration> EXTENSION = ReuseDropwizardAppExtensionTestSuite.EXTENSION;
 
     @Test
-    public void clientHasNotBeenClosed() {
+    void clientHasNotBeenClosed() {
         final String response = EXTENSION.client()
                 .target("http://localhost:" + EXTENSION.getAdminPort() + "/tasks/echo")
                 .request()


### PR DESCRIPTION
###### Problem:
Dropwizard documentation is not up-to-date: it uses JUnit4 examples whereas JUnit4 rules and such are now deprecated in `dropwizard-testing`.


###### Solution:
Replace JUnit4 examples with newest default JUnit5 examples. This is mostly replacing `@Rule` annotation with `@DropwizardAppExtension`. 

*Note*: I also did a small refactoring on JUnit5 to better match JUnit5 conventions (e.g. no need for `public` modifier anymore), let me know if that's okay and/or if you want me to make another PR for this change.

Closes #1 